### PR TITLE
fix: react native INVALID_STATE_ERR reactnative 闪退

### DIFF
--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -150,6 +150,10 @@ export class WKWebsocket {
             if(data instanceof Uint8Array) {
                 this.ws.send({ data:data.buffer })
             }else {
+                if (this.ws.readyState !== WebSocket.OPEN) {
+                    console.log('ws尚未连接，无法发送消息: ', this.ws.readyState)
+                    return
+                }
                 this.ws.send({ data })
             }
             


### PR DESCRIPTION
在react native中使用wukongjssdk，当应用从后台切换到前台时会出现闪退的情况，经排查发现是 websocket 连接还未建立成功就调用websocket.send。